### PR TITLE
Take screenshots of each story table step and avoid caching?

### DIFF
--- a/.github/workflows/run_form_tests.yml
+++ b/.github/workflows/run_form_tests.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           SERVER_URL: "${{ secrets.SERVER_URL }}"
           DOCASSEMBLE_DEVELOPER_API_KEY: "${{ secrets.DOCASSEMBLE_DEVELOPER_API_KEY }}"
+          ALKILN_VERSION: "4.10.4-feat-debug-cache"
       - run: echo "Finished running ALKiln tests"
       
       ## To make a new issue in your repository when a test fails,


### PR DESCRIPTION
Take screenshots of each story table step and use new project name to try to avoid this caching problem we've been having. Either way, we might want to restart your server at some point.

The tests are failing correctly. I tested them manually.